### PR TITLE
Correction of the values in the code

### DIFF
--- a/MotorbikesAccidentsEncounterForm.html
+++ b/MotorbikesAccidentsEncounterForm.html
@@ -117,8 +117,8 @@
         <select class="form-control" id="obs.injury_suffered" name="obs.injury_suffered" required="required"
             data-concept="9261^Did you suffer injuries?^99DCT">
             <option value="">...</option>
-            <option value="1065^YES^99DCT">Yes</option>
-            <option value="1066^NO^99DCT">No</option>
+            <option value="YES">Yes</option>
+            <option value="NO">No</option>
         </select>
     </div>
      <div class="form-group">


### PR DESCRIPTION
The values are displayed with their Concept ID when validated (YES & NO).
Example: instead of displaying "NO"; it displays "1066^NO^99DCT